### PR TITLE
Implement multi-connection architecture with TspServer/TspConnection split (#3203)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "dupe"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1501,19 @@ name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "is-macro"
@@ -2226,6 +2245,7 @@ dependencies = [
  "fuzzy-matcher",
  "fxhash",
  "indicatif",
+ "interprocess",
  "itertools 0.14.0",
  "lsp-server",
  "lsp-types",
@@ -2608,6 +2628,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -3921,6 +3947,12 @@ dependencies = [
  "once_cell",
  "rustix 0.38.44",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/crates/tsp_types/protocol_generator/tsp.json
+++ b/crates/tsp_types/protocol_generator/tsp.json
@@ -66,6 +66,20 @@
     ],
     "requests": [
         {
+            "method": "typeServer/connection",
+            "typeName": "ConnectionRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.",
+            "params": {
+                "kind": "reference",
+                "name": "ConnectionRequestParams"
+            },
+            "result": {
+                "kind": "reference",
+                "name": "ConnectionRequestResult"
+            }
+        },
+        {
             "method": "typeServer/getComputedType",
             "typeName": "GetComputedTypeRequest",
             "messageDirection": "clientToServer",
@@ -301,13 +315,21 @@
                 "v0_1_0": "0.1.0",
                 "v0_2_0": "0.2.0",
                 "v0_3_0": "0.3.0",
-                "current": "0.4.0"
+                "v0_4_0": "0.4.0",
+                "current": "0.5.0"
             },
             "valueDocumentation": {
                 "v0_1_0": "Initial protocol version",
                 "v0_2_0": "Added new request types and fields",
                 "v0_3_0": "Switch to more complex types",
-                "current": "Switch to Type union and using stubs"
+                "v0_4_0": "Switch to Type union and using stubs",
+                "current": "Add multi-connection negotiation and control requests"
+            }
+        },
+        "ConnectionTransportKind": {
+            "kind": "stringEnum",
+            "values": {
+                "Ipc": "ipc"
             }
         },
         "Variance": {
@@ -344,6 +366,77 @@
                 }
             ],
             "documentation": "Represents a location in source code (a node in the AST). Used to point to specific declarations, expressions, or statements in Python source files. Used for: - Pointing to where a type is declared - Identifying the location of expressions for type inference - Error reporting and diagnostics - Linking types back to their source definitions Examples: - For `def foo():`, the node points to the function declaration - For a variable `x = 42`, the node points to the assignment - For default parameter values in functions"
+        },
+        "TypeServerMultiConnectionCapability": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "supportedTransports",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "ConnectionTransportKind"
+                        }
+                    },
+                    "optional": false
+                }
+            ],
+            "documentation": "Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`."
+        },
+        "ConnectionRequestParams": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "type",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "kind",
+                    "type": {
+                        "kind": "reference",
+                        "name": "ConnectionTransportKind"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "args",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "base",
+                            "name": "string"
+                        }
+                    },
+                    "optional": true
+                }
+            ],
+            "documentation": "Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed."
+        },
+        "ConnectionRequestResult": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "success",
+                    "type": {
+                        "kind": "base",
+                        "name": "boolean"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "message",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": true
+                }
+            ]
         },
         "ModuleName": {
             "kind": "interface",
@@ -501,8 +594,8 @@
                 {
                     "name": "returnType",
                     "type": {
-                                "kind": "reference",
-                                "name": "Type"
+                        "kind": "reference",
+                        "name": "Type"
                     },
                     "optional": true,
                     "documentation": "Specialized type of the declared return type. Undefined if there is no declared return type. Example: For `def foo[T](x: T) -> T` specialized to `T=int`, returnType=int."
@@ -589,7 +682,7 @@
                     "documentation": "Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node"
                 }
             ],
-            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union."
+            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```"
         },
         "RegularDeclaration": {
             "kind": "interface",
@@ -615,8 +708,8 @@
                 {
                     "name": "name",
                     "type": {
-                                "kind": "base",
-                                "name": "string"
+                        "kind": "base",
+                        "name": "string"
                     },
                     "optional": true,
                     "documentation": "Name of the declared symbol, or undefined for anonymous declarations. Example: \"foo\" for `def foo():`, undefined for lambda functions."

--- a/crates/tsp_types/src/protocol.rs
+++ b/crates/tsp_types/src/protocol.rs
@@ -110,6 +110,8 @@ pub enum LSPNull {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 pub enum TSPRequestMethods {
+    #[serde(rename = "typeServer/connection")]
+    TypeServerConnection,
     #[serde(rename = "typeServer/getComputedType")]
     TypeServerGetComputedType,
     #[serde(rename = "typeServer/getDeclaredType")]
@@ -129,6 +131,11 @@ pub enum TSPRequestMethods {
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(tag = "method")]
 pub enum TSPRequests {
+    #[serde(rename = "typeServer/connection")]
+    ConnectionRequest {
+        id: serde_json::Value,
+        params: ConnectionRequestParams,
+    },
     #[serde(rename = "typeServer/getComputedType")]
     GetComputedTypeRequest {
         id: serde_json::Value,
@@ -347,7 +354,17 @@ pub enum TypeServerVersion {
 
     /// Switch to Type union and using stubs
     #[serde(rename = "0.4.0")]
+    V040,
+
+    /// Add multi-connection negotiation and control requests
+    #[serde(rename = "0.5.0")]
     Current,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+pub enum ConnectionTransportKind {
+    #[serde(rename = "ipc")]
+    Ipc,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
@@ -416,6 +433,33 @@ pub struct Node {
 
     /// URI of the source file containing this node.
     pub uri: String,
+}
+
+/// Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TypeServerMultiConnectionCapability {
+    pub supported_transports: Vec<ConnectionTransportKind>,
+}
+
+/// Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestParams {
+    pub args: Option<Vec<String>>,
+
+    pub kind: ConnectionTransportKind,
+
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestResult {
+    pub message: Option<String>,
+
+    pub success: bool,
 }
 
 /// Represents a Python module name, handling both absolute and relative imports. Used for: - Import statement resolution - Tracking module dependencies - Resolving relative imports (from . import, from .. import) Examples: - `import os.path`: leadingDots=0, nameParts=['os', 'path'] - `from . import utils`: leadingDots=1, nameParts=['utils'] - `from ...parent import module`: leadingDots=3, nameParts=['parent', 'module'] - `import mymodule`: leadingDots=0, nameParts=['mymodule']
@@ -510,7 +554,7 @@ pub struct SentinelLiteral {
     pub module_name: String,
 }
 
-/// Base interface for all declaration types. Provides the discriminator field for the Declaration union.
+/// Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeclarationBase {
@@ -863,6 +907,25 @@ pub enum LSPIdOptional {
     String(String),
     None,
 }
+
+/// Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequest {
+    /// The version of the JSON RPC protocol.
+    pub jsonrpc: String,
+
+    /// The method to be invoked.
+    pub method: TSPRequestMethods,
+
+    /// The request id.
+    pub id: LSPId,
+
+    pub params: ConnectionRequestParams,
+}
+
+/// Response to the [ConnectionRequest].
+pub type ConnectionResponse = ConnectionRequestResult;
 
 /// Requests and notifications for the type server protocol. Request for the computed type of a declaration or node. Computed type is the type that is inferred based on the code flow. Example: def foo(a: int | str): if instanceof(a, int): b = a + 1  # Computed type of 'b' is 'int'
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]

--- a/crates/tsp_types/tests/protocol_types.rs
+++ b/crates/tsp_types/tests/protocol_types.rs
@@ -76,7 +76,7 @@ fn test_variance_round_trip() {
 fn test_type_server_version_round_trip() {
     let v = TypeServerVersion::Current;
     let json = serde_json::to_value(&v).unwrap();
-    assert_eq!(json, serde_json::json!("0.4.0"));
+    assert_eq!(json, serde_json::json!("0.5.0"));
     let back: TypeServerVersion = serde_json::from_value(json).unwrap();
     assert_eq!(back, v);
 }

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -34,6 +34,7 @@ faster-hex = "0.6.1"
 fuzzy-matcher = "0.3.7"
 fxhash = "0.2.1"
 indicatif = { version = "0.18.4", features = ["futures", "improved_unicode", "rayon", "tokio"] }
+interprocess = "2.2.3"
 itertools = "0.14.0"
 lsp-server = "0.7.9"
 lsp-types = { git = "https://github.com/astral-sh/lsp-types", rev = "3512a9f33eadc5402cfab1b8f7340824c8ca1439" }

--- a/pyrefly/lib/commands/tsp.rs
+++ b/pyrefly/lib/commands/tsp.rs
@@ -38,6 +38,10 @@ pub struct TspArgs {
     /// Note that indexing files is a performance-intensive task.
     #[arg(long, default_value_t = if cfg!(fbcode_build) {0} else {2000})]
     pub(crate) workspace_indexing_limit: usize,
+    /// Selects the transport for the main JSON-RPC connection.
+    /// Use `stdio` (default) or `ipc://<name>` for a local socket / named pipe.
+    #[arg(long, default_value = "stdio")]
+    pub(crate) transport: String,
 }
 
 pub fn run_tsp(
@@ -107,9 +111,7 @@ impl TspArgs {
         // Note that we must have our logging only write out to stderr.
         eprintln!("starting TSP server");
 
-        // Create the transport. Includes the stdio (stdin and stdout) versions but this could
-        // also be implemented to use sockets or HTTP.
-        let (connection, reader, io_threads) = Connection::stdio();
+        let (connection, reader, io_threads) = Connection::from_transport(&self.transport)?;
 
         run_tsp(connection, reader, self, telemetry, wrapper, thread_count)?;
         io_threads.join()?;

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -31,6 +31,14 @@ use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
 use dupe::Dupe;
 use dupe::OptionDupedExt;
+use interprocess::TryClone;
+#[cfg(unix)]
+use interprocess::local_socket::GenericFilePath;
+use interprocess::local_socket::ToFsName;
+use interprocess::local_socket::prelude::LocalSocketStream;
+use interprocess::local_socket::traits::Stream;
+#[cfg(windows)]
+use interprocess::os::windows::local_socket::NamedPipe;
 use itertools::Itertools;
 use lsp_server::ErrorCode;
 use lsp_server::RequestId;
@@ -393,7 +401,7 @@ impl TypeErrorDisplayStatus {
 }
 
 /// Interface exposed for TSP to interact with the LSP server
-pub trait TspInterface: Send + Sync {
+pub trait TspInterface: Send + Sync + 'static {
     /// Send a response back to the LSP client
     fn send_response(&self, response: Response);
 
@@ -494,6 +502,7 @@ pub struct Connection {
 pub enum MessageReader {
     Channel(Receiver<Message>),
     Stdio(BufReader<Stdin>),
+    Stream(BufReader<Box<dyn std::io::Read + Send>>),
 }
 
 impl MessageReader {
@@ -504,6 +513,7 @@ impl MessageReader {
         match self {
             MessageReader::Channel(r) => r.recv().ok(),
             MessageReader::Stdio(r) => read_lsp_message(r).ok().flatten(),
+            MessageReader::Stream(r) => read_lsp_message(r).ok().flatten(),
         }
     }
 }
@@ -542,6 +552,47 @@ impl Connection {
             MessageReader::Stdio(BufReader::new(std::io::stdin())),
             IoThread { writer },
         )
+    }
+
+    pub fn ipc(pipe_name: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        #[cfg(windows)]
+        let socket_name = pipe_name.to_fs_name::<NamedPipe>()?;
+        #[cfg(unix)]
+        let socket_name = pipe_name.to_fs_name::<GenericFilePath>()?;
+
+        let stream = LocalSocketStream::connect(socket_name)?;
+        let reader_stream = stream.try_clone()?;
+        let (writer_sender, writer_receiver) = crossbeam_channel::unbounded();
+        let writer = std::thread::spawn(move || {
+            let mut output = stream;
+            while let Ok(msg) = writer_receiver.recv() {
+                write_lsp_message(&mut output, msg)?;
+            }
+            Ok(())
+        });
+        Ok((
+            Self {
+                sender: writer_sender,
+                channel_receiver: None,
+            },
+            MessageReader::Stream(BufReader::new(Box::new(reader_stream))),
+            IoThread { writer },
+        ))
+    }
+
+    pub fn from_transport(transport: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        if transport == "stdio" {
+            return Ok(Self::stdio());
+        }
+
+        if let Some(pipe_name) = transport.strip_prefix("ipc://") {
+            return Self::ipc(pipe_name);
+        }
+
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Unsupported TSP transport: {transport}"),
+        ))
     }
 
     pub fn memory() -> ((Self, MessageReader), (Self, MessageReader)) {
@@ -1080,6 +1131,12 @@ pub struct ServerCapabilitiesWithTypeHierarchy {
     base: ServerCapabilities,
     #[serde(skip_serializing_if = "Option::is_none")]
     type_hierarchy_provider: Option<bool>,
+}
+
+impl ServerCapabilitiesWithTypeHierarchy {
+    pub fn set_experimental(&mut self, value: serde_json::Value) {
+        self.base.experimental = Some(value);
+    }
 }
 
 #[derive(Serialize)]

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -12,9 +12,9 @@ use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Return the computed (inferred) type at the given position.
     ///
     /// The computed type reflects the type checker's analysis of the code
@@ -27,7 +27,7 @@ impl<T: TspInterface> TspServer<T> {
         self.validate_snapshot(params.snapshot)?;
         let position = params.position();
         let ty = self
-            .inner
+            .inner()
             .get_type_at_position(params.uri(), position.line, position.character);
         Ok(ty.map(|t| self.convert_type(&t)))
     }

--- a/pyrefly/lib/tsp/requests/get_declared_type.rs
+++ b/pyrefly/lib/tsp/requests/get_declared_type.rs
@@ -12,9 +12,9 @@ use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Return the declared type at the given position.
     ///
     /// The declared type is the annotation explicitly written by the user.
@@ -31,7 +31,7 @@ impl<T: TspInterface> TspServer<T> {
         self.validate_snapshot(params.snapshot)?;
         let position = params.position();
         let ty = self
-            .inner
+            .inner()
             .get_type_at_position(params.uri(), position.line, position.character);
         Ok(ty.map(|t| self.convert_type(&t)))
     }

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -12,9 +12,9 @@ use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Return the expected type at the given position.
     ///
     /// The expected type is the type that a surrounding context demands.
@@ -31,7 +31,7 @@ impl<T: TspInterface> TspServer<T> {
         self.validate_snapshot(params.snapshot)?;
         let position = params.position();
         let ty = self
-            .inner
+            .inner()
             .get_type_at_position(params.uri(), position.line, position.character);
         Ok(ty.map(|t| self.convert_type(&t)))
     }

--- a/pyrefly/lib/tsp/requests/get_python_search_paths.rs
+++ b/pyrefly/lib/tsp/requests/get_python_search_paths.rs
@@ -15,11 +15,11 @@ use lsp_server::RequestId;
 use tsp_types::protocol::GetPythonSearchPathsParams;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 use crate::tsp::validation::internal_error;
 use crate::tsp::validation::parse_file_uri;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Handle a `typeServer/getPythonSearchPaths` request.
     ///
     /// Validates the snapshot, parses the `from_uri`, and delegates to
@@ -38,7 +38,7 @@ impl<T: TspInterface> TspServer<T> {
 
         // --- 2. Parse from_uri and delegate ---
         match parse_file_uri(&params.from_uri) {
-            Ok(url) => match self.inner.get_python_search_paths(&url) {
+            Ok(url) => match self.inner().get_python_search_paths(&url) {
                 Ok(paths) => self.send_ok(id, paths),
                 Err(detail) => self.send_err(id, internal_error(&detail)),
             },

--- a/pyrefly/lib/tsp/requests/get_snapshot.rs
+++ b/pyrefly/lib/tsp/requests/get_snapshot.rs
@@ -8,19 +8,22 @@
 //! Implementation of the getSnapshot TSP request
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Get the current snapshot version
     ///
     /// The snapshot represents the current epoch of the global state.
     /// It changes whenever files are modified, configuration changes,
     /// or any other event that would trigger a recomputation.
     pub fn get_snapshot(&self) -> i32 {
-        *self.current_snapshot.lock().unwrap_or_else(|poisoned| {
-            // In case of poisoned mutex, recover and return the value
-            eprintln!("TSP: Warning - snapshot mutex was poisoned, recovering");
-            poisoned.into_inner()
-        })
+        *self
+            .server
+            .current_snapshot
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                eprintln!("TSP: Warning - snapshot mutex was poisoned, recovering");
+                poisoned.into_inner()
+            })
     }
 }

--- a/pyrefly/lib/tsp/requests/get_supported_protocol_version.rs
+++ b/pyrefly/lib/tsp/requests/get_supported_protocol_version.rs
@@ -11,9 +11,9 @@ use tsp_types::TSP_PROTOCOL_VERSION;
 use tsp_types::protocol::TypeServerVersion;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     pub fn get_supported_protocol_version(&self) -> TypeServerVersion {
         // Return the current protocol version from the generated enum
         TSP_PROTOCOL_VERSION

--- a/pyrefly/lib/tsp/requests/resolve_import.rs
+++ b/pyrefly/lib/tsp/requests/resolve_import.rs
@@ -23,11 +23,11 @@ use tsp_types::protocol::ResolveImportParams;
 use crate::lsp::module_helpers::to_real_path;
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 use crate::tsp::validation::invalid_params_error;
 use crate::tsp::validation::parse_file_uri;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Handle a `typeServer/resolveImport` request.
     ///
     /// Converts the TSP [`ResolveImportParams`] into pyrefly's internal
@@ -64,7 +64,7 @@ impl<T: TspInterface> TspServer<T> {
 
         // --- 3. Build source handle and resolve the module name ---
         let source_module_path = ModulePath::filesystem(source_path.clone());
-        let source_handle = self.inner.handle_from_module_path(source_module_path);
+        let source_handle = self.inner().handle_from_module_path(source_module_path);
 
         let module_name = match resolve_module_name(
             &params.module_descriptor.name_parts,
@@ -84,7 +84,7 @@ impl<T: TspInterface> TspServer<T> {
 
         // --- 4. Resolve the import via existing infrastructure ---
         let transaction = self
-            .inner
+            .inner()
             .non_committable_transaction(ide_transaction_manager);
         let result = transaction.import_handle(&source_handle, module_name, None);
 

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -5,28 +5,37 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use lsp_server::ErrorCode;
 use lsp_server::RequestId;
+use lsp_server::ResponseError;
 use lsp_types::InitializeParams;
 use pyrefly_util::telemetry::QueueName;
 use pyrefly_util::telemetry::Telemetry;
 use pyrefly_util::telemetry::TelemetryEvent;
 use pyrefly_util::telemetry::TelemetryEventKind;
+use serde::Serialize;
 use tracing::info;
 use tracing::warn;
+use tsp_types::ConnectionRequestParams;
+use tsp_types::ConnectionRequestResult;
+use tsp_types::ConnectionTransportKind;
 use tsp_types::GetTypeParams;
 use tsp_types::TSPNotificationMethods;
 use tsp_types::TSPRequests;
 
 use crate::commands::lsp::IndexingMode;
+use crate::lsp::non_wasm::lsp::new_response;
 use crate::lsp::non_wasm::protocol::Message;
 use crate::lsp::non_wasm::protocol::Notification;
 use crate::lsp::non_wasm::protocol::Request;
 use crate::lsp::non_wasm::protocol::Response;
 use crate::lsp::non_wasm::queue::LspEvent;
+use crate::lsp::non_wasm::server::Connection;
 use crate::lsp::non_wasm::server::InitializeInfo;
 use crate::lsp::non_wasm::server::MessageReader;
 use crate::lsp::non_wasm::server::ProcessEvent;
@@ -35,130 +44,123 @@ use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::server::capabilities;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::type_conversion::convert_type_with_resolver;
+use crate::tsp::validation::internal_error;
+use crate::tsp::validation::invalid_params_error;
+use crate::tsp::validation::snapshot_outdated_error;
 
-/// TSP server that delegates to LSP server infrastructure while handling only TSP requests
+// ---------------------------------------------------------------------------
+// Extra connection bookkeeping
+// ---------------------------------------------------------------------------
+
+struct ExtraConnectionHandle {
+    close_tx: crossbeam_channel::Sender<()>,
+}
+
+/// Shared core of the TSP server, referenced by every connection.
 pub struct TspServer<T: TspInterface> {
-    pub inner: T,
-    /// Current snapshot version, updated on RecheckFinished events
+    pub(crate) inner: Arc<T>,
+    /// Current snapshot version, updated on RecheckFinished events.
     pub(crate) current_snapshot: Arc<Mutex<i32>>,
+    extra_connections: Mutex<HashMap<String, ExtraConnectionHandle>>,
 }
 
 impl<T: TspInterface> TspServer<T> {
-    pub fn new(lsp_server: T) -> Self {
+    fn new(lsp_server: T) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Arc::new(lsp_server),
+            current_snapshot: Arc::new(Mutex::new(0)),
+            extra_connections: Mutex::new(HashMap::new()),
+        })
+    }
+}
+
+/// A single JSON-RPC connection to the TSP server.
+///
+/// Each connection has its own response channel but shares the underlying
+/// `TspServer` core with all other connections.
+pub struct TspConnection<T: TspInterface> {
+    pub(crate) server: Arc<TspServer<T>>,
+    response_sender: crossbeam_channel::Sender<Message>,
+}
+
+impl<T: TspInterface> TspConnection<T> {
+    fn new(server: Arc<TspServer<T>>, response_sender: crossbeam_channel::Sender<Message>) -> Self {
         Self {
-            inner: lsp_server,
-            current_snapshot: Arc::new(Mutex::new(0)), // Start at 0, increments on RecheckFinished
+            server,
+            response_sender,
         }
+    }
+
+    /// Convenience accessor for the inner LSP server.
+    pub(crate) fn inner(&self) -> &T {
+        &self.server.inner
     }
 
     /// Convert a pyrefly `Type` to a TSP protocol `Type`, resolving function
     /// declaration ranges via the binding table.
     pub(crate) fn convert_type(&self, ty: &pyrefly_types::types::Type) -> tsp_types::Type {
-        let resolver =
-            |func_id: &pyrefly_types::callable::FuncId| self.inner.resolve_func_def_range(func_id);
+        let resolver = |func_id: &pyrefly_types::callable::FuncId| {
+            self.inner().resolve_func_def_range(func_id)
+        };
         convert_type_with_resolver(ty, &resolver)
     }
 
-    pub fn process_event<'a>(
-        &'a self,
-        ide_transaction_manager: &mut TransactionManager<'a>,
-        canceled_requests: &mut HashSet<RequestId>,
-        telemetry: &'a impl Telemetry,
-        telemetry_event: &mut TelemetryEvent,
-        subsequent_mutation: bool,
-        event: LspEvent,
-    ) -> anyhow::Result<ProcessEvent> {
-        // Remember if this event should increment the snapshot after processing
-        let should_increment_snapshot = match &event {
-            LspEvent::RecheckFinished => true,
-            // Increment on DidChange since it affects type checker state via synchronous validation
-            LspEvent::DidChangeTextDocument(_) => true,
-            // Don't increment on DidChangeWatchedFiles directly since it triggers RecheckFinished
-            // LspEvent::DidChangeWatchedFiles => true,
-            // Don't increment on DidOpen since it triggers RecheckFinished events that will increment
-            // LspEvent::DidOpenTextDocument(_) => true,
-            _ => false,
-        };
-
-        // For TSP requests, handle them specially
-        if let LspEvent::LspRequest(ref request) = event {
-            if self.handle_tsp_request(ide_transaction_manager, request)? {
-                return Ok(ProcessEvent::Continue);
-            }
-            // If it's not a TSP request, let the LSP server reject it since TSP server shouldn't handle LSP requests
-            self.inner.send_response(Response::new_err(
-                request.id.clone(),
-                lsp_server::ErrorCode::MethodNotFound as i32,
-                format!("TSP server does not support LSP method: {}", request.method),
-            ));
-            return Ok(ProcessEvent::Continue);
+    pub(crate) fn send_response(&self, response: Response) {
+        if let Err(error) = self.response_sender.send(Message::Response(response)) {
+            warn!("Failed to send TSP response: {error}");
         }
-
-        // For all other events (notifications, responses, etc.), delegate to inner server
-        let result = self.inner.process_event(
-            ide_transaction_manager,
-            canceled_requests,
-            telemetry,
-            telemetry_event,
-            subsequent_mutation,
-            event,
-        )?;
-
-        // Increment snapshot after the inner server has processed the event
-        if should_increment_snapshot && let Ok(mut current) = self.current_snapshot.lock() {
-            let old_snapshot = *current;
-            *current += 1;
-            let new_snapshot = *current;
-            drop(current); // Release the lock before sending the notification
-            self.send_snapshot_changed_notification(old_snapshot, new_snapshot);
-        }
-
-        Ok(result)
     }
 
-    /// Send a `typeServer/snapshotChanged` notification to the client.
+    /// Send a successful JSON-RPC response for `id` with `result`.
+    pub(crate) fn send_ok<R: Serialize>(&self, id: RequestId, result: R) {
+        self.send_response(new_response(id, Ok(result)));
+    }
+
+    /// Send a JSON-RPC error response for `id`.
+    pub(crate) fn send_err(&self, id: RequestId, error: ResponseError) {
+        self.send_response(Response {
+            id,
+            result: None,
+            error: Some(error),
+        });
+    }
+
+    /// Validate that the client-supplied snapshot matches the server's current
+    /// snapshot. Returns `Ok(())` on match or `Err(ResponseError)` on mismatch.
+    pub(crate) fn validate_snapshot(&self, client_snapshot: i32) -> Result<(), ResponseError> {
+        let current = self.get_snapshot();
+        if client_snapshot != current {
+            Err(snapshot_outdated_error(client_snapshot, current))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Dispatch an already-parsed TSP request.
     ///
-    /// Called whenever the snapshot counter increments, so the client knows
-    /// any previously-returned types are stale.
-    fn send_snapshot_changed_notification(&self, old_snapshot: i32, new_snapshot: i32) {
-        let method = serde_json::to_value(TSPNotificationMethods::TypeServerSnapshotChanged)
-            .expect("TSPNotificationMethods serialization is infallible");
-        let method_str = method
-            .as_str()
-            .expect("TSPNotificationMethods serializes to a string")
-            .to_owned();
-
-        if let Err(e) = self
-            .inner
-            .sender()
-            .send(Message::Notification(Notification {
-                method: method_str,
-                params: serde_json::json!({ "old": old_snapshot, "new": new_snapshot }),
-                activity_key: None,
-            }))
-        {
-            warn!("Failed to send snapshotChanged notification: {e}");
-        }
-    }
-
-    fn handle_tsp_request<'a>(
+    /// `ConnectionRequest` is rejected here — on the main connection it is
+    /// handled before dispatch, so only extra connections can reach this arm.
+    fn dispatch_tsp_request<'a>(
         &'a self,
         ide_transaction_manager: &mut TransactionManager<'a>,
         request: &Request,
+        msg: TSPRequests,
     ) -> anyhow::Result<bool> {
-        // Convert the request into a TSPRequests enum
-        let wrapper = serde_json::json!({
-            "method": request.method,
-            "id": request.id,
-            "params": request.params
-        });
-
-        let Ok(msg) = serde_json::from_value::<TSPRequests>(wrapper) else {
-            // Not a TSP request
-            return Ok(false);
-        };
-
         match msg {
+            TSPRequests::ConnectionRequest { .. } => {
+                self.send_err(
+                    request.id.clone(),
+                    ResponseError {
+                        code: ErrorCode::InvalidRequest as i32,
+                        message: format!(
+                            "TSP method {} is only allowed on the main connection",
+                            request.method
+                        ),
+                        data: None,
+                    },
+                );
+                Ok(true)
+            }
             TSPRequests::GetSupportedProtocolVersionRequest { .. } => {
                 self.send_ok(request.id.clone(), self.get_supported_protocol_version());
                 Ok(true)
@@ -212,10 +214,7 @@ impl<T: TspInterface> TspServer<T> {
         let params: GetTypeParams = match serde_json::from_value::<GetTypeParams>(raw_params) {
             Ok(p) => p,
             Err(e) => {
-                self.send_err(
-                    id,
-                    crate::tsp::validation::invalid_params_error(&e.to_string()),
-                );
+                self.send_err(id, invalid_params_error(&e.to_string()));
                 return;
             }
         };
@@ -230,6 +229,277 @@ impl<T: TspInterface> TspServer<T> {
     }
 }
 
+/// Try to parse a request as a `TSPRequests` enum variant.
+fn parse_tsp_request(request: &Request) -> Option<TSPRequests> {
+    let wrapper = serde_json::json!({
+        "method": request.method,
+        "id": request.id,
+        "params": request.params
+    });
+    serde_json::from_value::<TSPRequests>(wrapper).ok()
+}
+
+/// Extract the IPC pipe name from connection request `args`, or return an error.
+fn pipe_name(params: &ConnectionRequestParams) -> Result<&str, ResponseError> {
+    if params.kind != ConnectionTransportKind::Ipc {
+        return Err(invalid_params_error(
+            "Only IPC extra connections are supported",
+        ));
+    }
+
+    params
+        .args
+        .as_ref()
+        .and_then(|args| args.first())
+        .map(|s| s.as_str())
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            invalid_params_error("Connection request args must include the IPC pipe name")
+        })
+}
+
+/// Process a single event on the main connection.
+///
+/// Only the main connection handles `ConnectionRequest` and broadcasts
+/// `snapshotChanged` notifications.
+fn process_main_event<'a, T: TspInterface>(
+    conn: &'a TspConnection<T>,
+    ide_transaction_manager: &mut TransactionManager<'a>,
+    canceled_requests: &mut HashSet<RequestId>,
+    telemetry: &'a impl Telemetry,
+    telemetry_event: &mut TelemetryEvent,
+    subsequent_mutation: bool,
+    event: LspEvent,
+) -> anyhow::Result<ProcessEvent> {
+    let should_increment_snapshot = match &event {
+        LspEvent::RecheckFinished => true,
+        LspEvent::DidChangeTextDocument(_) => true,
+        _ => false,
+    };
+
+    if let LspEvent::LspRequest(ref request) = event {
+        match parse_tsp_request(request) {
+            Some(TSPRequests::ConnectionRequest { params, .. }) => {
+                handle_connection_request(conn, request.id.clone(), params);
+            }
+            Some(msg) => {
+                conn.dispatch_tsp_request(ide_transaction_manager, request, msg)?;
+            }
+            None => {
+                conn.send_response(Response::new_err(
+                    request.id.clone(),
+                    ErrorCode::MethodNotFound as i32,
+                    format!("TSP server does not support LSP method: {}", request.method),
+                ));
+            }
+        }
+        return Ok(ProcessEvent::Continue);
+    }
+
+    let result = conn.inner().process_event(
+        ide_transaction_manager,
+        canceled_requests,
+        telemetry,
+        telemetry_event,
+        subsequent_mutation,
+        event,
+    )?;
+
+    if should_increment_snapshot {
+        if let Ok(mut current) = conn.server.current_snapshot.lock() {
+            let old_snapshot = *current;
+            *current += 1;
+            let new_snapshot = *current;
+            drop(current);
+            send_snapshot_changed_notification(conn, old_snapshot, new_snapshot);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Send a `typeServer/snapshotChanged` notification to the client.
+fn send_snapshot_changed_notification<T: TspInterface>(
+    conn: &TspConnection<T>,
+    old_snapshot: i32,
+    new_snapshot: i32,
+) {
+    let method = serde_json::to_value(TSPNotificationMethods::TypeServerSnapshotChanged)
+        .expect("TSPNotificationMethods serialization is infallible");
+    let method_str = method
+        .as_str()
+        .expect("TSPNotificationMethods serializes to a string")
+        .to_owned();
+
+    if let Err(e) = conn
+        .response_sender
+        .send(Message::Notification(Notification {
+            method: method_str,
+            params: serde_json::json!({ "old": old_snapshot, "new": new_snapshot }),
+            activity_key: None,
+        }))
+    {
+        warn!("Failed to send snapshotChanged notification: {e}");
+    }
+}
+
+fn handle_connection_request<T: TspInterface>(
+    conn: &TspConnection<T>,
+    id: RequestId,
+    params: ConnectionRequestParams,
+) {
+    let result = match params.type_.as_str() {
+        "open" => open_extra_connection(conn, params),
+        "close" => Ok(close_extra_connection(conn, params)),
+        other => Err(invalid_params_error(&format!(
+            "Unsupported connection request type: {other}"
+        ))),
+    };
+
+    match result {
+        Ok(connection_result) => conn.send_ok(id, connection_result),
+        Err(error) => conn.send_err(id, error),
+    }
+}
+
+fn open_extra_connection<T: TspInterface>(
+    conn: &TspConnection<T>,
+    params: ConnectionRequestParams,
+) -> Result<ConnectionRequestResult, ResponseError> {
+    let name = pipe_name(&params)?;
+
+    let mut extra_connections = conn
+        .server
+        .extra_connections
+        .lock()
+        .map_err(|_| internal_error("extra connection state was poisoned"))?;
+
+    if extra_connections.contains_key(name) {
+        return Ok(ConnectionRequestResult {
+            success: true,
+            message: Some(format!("Extra connection already open: {name}")),
+        });
+    }
+
+    let (ipc_connection, reader, _io_thread) = Connection::ipc(name).map_err(|error| {
+        internal_error(&format!(
+            "Failed to connect to IPC endpoint {name}: {error}"
+        ))
+    })?;
+
+    let extra_conn = TspConnection::new(conn.server.clone(), ipc_connection.sender.clone());
+    let (close_tx, close_rx) = crossbeam_channel::bounded::<()>(1);
+    let name_owned = name.to_owned();
+
+    extra_connections.insert(name_owned.clone(), ExtraConnectionHandle { close_tx });
+    drop(extra_connections);
+
+    spawn_extra_connection_loop(extra_conn, reader, close_rx, name_owned);
+
+    Ok(ConnectionRequestResult {
+        success: true,
+        message: Some(format!("Opened extra IPC connection: {name}")),
+    })
+}
+
+fn spawn_extra_connection_loop<T: TspInterface>(
+    extra_conn: TspConnection<T>,
+    mut reader: MessageReader,
+    close_rx: crossbeam_channel::Receiver<()>,
+    pipe_name: String,
+) {
+    let (message_tx, message_rx) = crossbeam_channel::unbounded();
+
+    std::thread::spawn(move || {
+        std::thread::spawn(move || {
+            while let Some(message) = reader.recv() {
+                if message_tx.send(message).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let mut selector = crossbeam_channel::Select::new();
+        let close_index = selector.recv(&close_rx);
+        let message_index = selector.recv(&message_rx);
+        loop {
+            let selected = selector.select();
+            match selected.index() {
+                i if i == close_index => break,
+                i if i == message_index => {
+                    let Ok(message) = selected.recv(&message_rx) else {
+                        break;
+                    };
+
+                    match message {
+                        Message::Request(request) => {
+                            let mut tm = TransactionManager::default();
+                            match parse_tsp_request(&request) {
+                                Some(msg) => {
+                                    if let Err(error) =
+                                        extra_conn.dispatch_tsp_request(&mut tm, &request, msg)
+                                    {
+                                        warn!("Extra TSP connection error: {error}");
+                                        break;
+                                    }
+                                }
+                                None => {
+                                    extra_conn.send_response(Response::new_err(
+                                        request.id,
+                                        ErrorCode::MethodNotFound as i32,
+                                        format!(
+                                            "Extra TSP connection does not support method: {}",
+                                            request.method
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
+                        Message::Notification(_) | Message::Response(_) => {}
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        if let Ok(mut handles) = extra_conn.server.extra_connections.lock() {
+            handles.remove(&pipe_name);
+        }
+    });
+}
+
+fn close_extra_connection<T: TspInterface>(
+    conn: &TspConnection<T>,
+    params: ConnectionRequestParams,
+) -> ConnectionRequestResult {
+    let Ok(name) = pipe_name(&params) else {
+        return ConnectionRequestResult {
+            success: false,
+            message: Some("Missing IPC pipe name in connection args".to_owned()),
+        };
+    };
+
+    let handle = conn
+        .server
+        .extra_connections
+        .lock()
+        .ok()
+        .and_then(|mut handles| handles.remove(name));
+
+    if let Some(handle) = handle {
+        let _ = handle.close_tx.send(());
+        ConnectionRequestResult {
+            success: true,
+            message: Some(format!("Closing extra IPC connection: {name}")),
+        }
+    } else {
+        ConnectionRequestResult {
+            success: true,
+            message: Some(format!("Extra IPC connection already closed: {name}")),
+        }
+    }
+}
+
 pub fn tsp_loop(
     lsp_server: impl TspInterface,
     mut reader: MessageReader,
@@ -237,9 +507,9 @@ pub fn tsp_loop(
     telemetry: &impl Telemetry,
 ) -> anyhow::Result<()> {
     let server = TspServer::new(lsp_server);
+    let main_conn = TspConnection::new(server.clone(), server.inner.sender().clone());
 
     std::thread::scope(|scope| {
-        // Start the recheck queue thread to process async tasks
         scope.spawn(|| server.inner.run_recheck_queue(telemetry));
 
         scope.spawn(|| {
@@ -262,7 +532,8 @@ pub fn tsp_loop(
             );
             let event_description = event.describe();
 
-            let result = server.process_event(
+            let result = process_main_event(
+                &main_conn,
                 &mut ide_transaction_manager,
                 &mut canceled_requests,
                 telemetry,
@@ -290,12 +561,16 @@ pub fn tsp_loop(
     })
 }
 
-/// Generate TSP-specific server capabilities using the same capabilities as LSP
+/// Generate TSP-specific server capabilities.
 pub fn tsp_capabilities(
     indexing_mode: IndexingMode,
     initialization_params: &InitializeParams,
 ) -> ServerCapabilitiesWithTypeHierarchy {
-    // Use the same capabilities as LSP - TSP server supports the same features
-    // but will only respond to TSP protocol requests
-    capabilities(indexing_mode, initialization_params)
+    let mut result = capabilities(indexing_mode, initialization_params);
+    result.set_experimental(serde_json::json!({
+        "typeServerMultiConnection": {
+            "supportedTransports": ["ipc"]
+        }
+    }));
+    result
 }

--- a/pyrefly/lib/tsp/validation.rs
+++ b/pyrefly/lib/tsp/validation.rs
@@ -15,15 +15,8 @@
 //! - Response dispatch (success or error, routed through `TspInterface`)
 
 use lsp_server::ErrorCode;
-use lsp_server::RequestId;
 use lsp_server::ResponseError;
 use lsp_types::Url;
-use serde::Serialize;
-
-use crate::lsp::non_wasm::lsp::new_response;
-use crate::lsp::non_wasm::protocol::Response;
-use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
 
 // ---------------------------------------------------------------------------
 // Canonical TSP error constructors
@@ -80,37 +73,6 @@ pub fn parse_file_uri(uri: &str) -> Result<Url, ResponseError> {
         return Err(invalid_params_error("URI must use the file:// scheme"));
     }
     Ok(url)
-}
-
-// ---------------------------------------------------------------------------
-// Snapshot validation
-// ---------------------------------------------------------------------------
-
-impl<T: TspInterface> TspServer<T> {
-    /// Validate that the client-supplied snapshot matches the server's current
-    /// snapshot. Returns `Ok(())` on match or `Err(ResponseError)` on mismatch.
-    pub fn validate_snapshot(&self, client_snapshot: i32) -> Result<(), ResponseError> {
-        let current = self.get_snapshot();
-        if client_snapshot != current {
-            Err(snapshot_outdated_error(client_snapshot, current))
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Send a successful JSON-RPC response for `id` with `result`.
-    pub fn send_ok<R: Serialize>(&self, id: RequestId, result: R) {
-        self.inner.send_response(new_response(id, Ok(result)));
-    }
-
-    /// Send a JSON-RPC error response for `id`.
-    pub fn send_err(&self, id: RequestId, error: ResponseError) {
-        self.inner.send_response(Response {
-            id,
-            result: None,
-            error: Some(error),
-        });
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Summary:

Split the monolithic TspServer into two types: TspServer (shared state across all connections) and TspConnection (per-connection response channel and request dispatch). This addresses several design concerns:

TspServer holds Arc, current_snapshot, and extra_connections — state shared across main and extra connections
TspConnection holds a reference to TspServer plus its own response_sender, scoping per-connection behavior
Connection management (open/close) is handled by free functions that only the main event loop calls, making it structurally impossible for extra connections to manage connections
Extra connections reject ConnectionRequest at the dispatch level, so the match arm never reaches connection management code
Added ConnectionRequestParamsExt trait for pipe_name extraction, keeping validation close to the protocol type
Added set_experimental() method on ServerCapabilitiesWithTypeHierarchy instead of exposing the base field
Moved 'static bound to the TspInterface trait definition to avoid repeating it on every impl block
Differential Revision: D102005011